### PR TITLE
Expose LoggerFactory so modules can use it

### DIFF
--- a/lib/bits-base.js
+++ b/lib/bits-base.js
@@ -144,6 +144,7 @@ limitations under the License.
    * Logging
    */
   const LoggerFactory = require('./logging/logger-factory');
+  global.helper.LoggerFactory = LoggerFactory;
 
   const logger = LoggerFactory.getLogger();
 


### PR DESCRIPTION
I wanted to be able to use the BITS logger within my modules, but it didn't seem to be available so I've mad e a patch to expose it via global.helper.

I would have preferred that the module be able to do:

```
const logger = require('logging/logger-factory').getLogger()
```

So that access to global.helper wasn't required, but the module doesn't have access to the node_modules installed via BITS (at least easily) so I followed the convention used by global.helper.Messenger.
