### PR TITLE
Add requestId within metadata so that requestHandlers can access it i…

### DIFF
--- a/lib/message-center.js
+++ b/lib/message-center.js
@@ -690,6 +690,8 @@ limitations under the License.
           logger.warn('Request listener must be called with a requestId...bad developer!: ', event, requestId, requestScopes, data);
           return;
         }
+        // Provide the requestId in case the handler wants it
+        metadata.requestId = requestId;
 
         if (!this._isValidScopes(requestScopes)) {
           logger.warn('Request listener must be called with a scope array ... bad developer!: ', event, requestId, requestScopes, data);


### PR DESCRIPTION
When writing the bits-node-ipc module I needed to be able to access the requestId when handling the request itself.  The easiest way to do that was simply including requestId within the metadata structure.

If there is an alternative approach or another preferred method for accomplishing the same behavior, please let me know.