### PR TITLE
Added a repository information to remove the 'npm WARN bits@2.3.0 No …

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
     "semver": "^5.3.0",
     "socket.io": "^1.7.1",
     "winston": "^2.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LGSInnovations/bits.git"
   }
 }


### PR DESCRIPTION
When you execute npm install you see a warning.  Even though is a warning I think we should remove it so I modified the package.json file and added the repository information.