### PR TITLE
Issue 19 portable bits id gen

### DIFF
--- a/lib/system/bits-id.js
+++ b/lib/system/bits-id.js
@@ -16,6 +16,7 @@ limitations under the License.
 (function() {
   'use strict';
 
+  const os = require('os');
   const path = require('path');
   const UtilFs = require('../helpers/fs');
   const UtilChildProcess = require('../helpers/child-process');
@@ -51,19 +52,35 @@ limitations under the License.
     }
 
     _generateId() {
-      const command = 'hostname';
-      const args = [];
-      const options = {};
+      // try node.js os.hostname first
+      let hostname = os.hostname();
+      // if that doesn't work try the HOSTNAME environment variable
+      if (!hostname) {
+        hostname = process.env.HOSTNAME;
+      }
+      // if we now have a hostname return it as a resolved promise,
+      // otherwise fall-back to the original behaviour that uses
+      // the hostname command. The hostname command is not portable
+      // and isn't guaranteed to exist on Linux.
+      if (hostname) {
+        return Promise.resolve(hostname);
+      } else {
+        const command = 'hostname';
+        const args = [];
+        const options = {};
 
-      return UtilChildProcess.spawn(command, args, options)
-      .then((results) => {
-        if (0 === results.code) {
-          const output = results.stdout.reduce((output, line) => output + line.trim(), '');
-          return output;
-        } else {
+        return UtilChildProcess.spawn(command, args, options)
+        .then((results) => {
+          if (0 === results.code) {
+            const output = results.stdout.reduce((output, line) => output + line.trim(), '');
+            return output;
+          } else {
+            return Promise.reject(new Error('Failed to get the bits id'));
+          }
+        }).catch((err) => {
           return Promise.reject(new Error('Failed to get the bits id'));
-        }
-      });
+        });
+      }
     }
 
     _writeBitsId(bitsId) {

--- a/test/test-bits-id.js
+++ b/test/test-bits-id.js
@@ -1,0 +1,49 @@
+/**
+Copyright 2017 LGS Innovations
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**/
+(() => {
+  'use strict';
+
+  const os = require('os');
+  const chai = require('chai');
+  const chaiAsPromised = require('chai-as-promised');
+
+  global.paths = global.paths || {};
+  global.paths = Object.assign(global.paths, {data: os.tmpdir()});
+
+  const BitsId = require('./../lib/system/bits-id');
+
+  const expect = chai.expect;
+
+  chai.use(chaiAsPromised);
+
+  describe('BitsId', () => {
+    let bitsId = null;
+
+    beforeEach('Create BitsId', () => {
+      bitsId = new BitsId();
+    });
+
+    describe('checkGenerateId', () => {
+
+      it('should return the equivalent to os.hostname', () => {
+        return bitsId._generateId()
+        .then((bitsId) => {
+          expect(bitsId).to.equal(os.hostname());
+        });
+      });
+    });
+  });
+})();


### PR DESCRIPTION
This commit includes a fix for issue 19.  The code attempts to us `os.hostname()` first, if that is empty it uses `process.env.HOSTNAME`, then as a final fallback it reverts to the original BITS behaviour of calling `hostname`.

All of these extra fallbacks are probably unnecessary and `os.hostname()` could simply be used by itself, but I kept the fallbacks just in case.

A unittest is also included so that if someone is on a system where _generateId() won't work it will fail during `npm run test` instead of when running the BITS server. 