### PR TITLE
docs: update README to include dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ BITS is built upon the NodeJS framework and requires that following
 
 
 * Linux Operating System, such as [Ubuntu LTS](https://www.ubuntu.com/download)
+* Build tools, such as [Build Essential](https://packages.ubuntu.com/xenial/build-essential)
 * [NodeJS LTS](https://nodejs.org/en/download)
 * [Yarn](https://yarnpkg.com/en/docs/install)
 * [Python 2.x](https://www.python.org/downloads)


### PR DESCRIPTION
In writing an ansible role to deploy to AWS, I found an undocumented dependency. npm run build fails without make, not being able to build leveldown.