### PR TITLE
Enhancement: send events from client:

### DIFF
--- a/app/elements/base-message-center/base-message-center-behavior.html
+++ b/app/elements/base-message-center/base-message-center-behavior.html
@@ -225,6 +225,37 @@ limitations under the License.
         });
       },
 
+      sendEvent: function(event, ...data) {
+        this._startLoading();
+        return this._waitUntilConnected()
+        .then(() => {
+          const socket = this.socket;
+          return new Promise((resolve, reject) => {
+            const requestId = getNextRequestId();
+            const onResponse = (meta, err, data) => {
+              if (event === meta.event && requestId === meta.responseId) {
+                socket.removeEventListener('response', onResponse);
+                this._stopLoading();
+                if (err) {
+                  if (meta && meta.reason) {
+                    this.fire('bits-base-error', {error: err, data: meta.data});
+                  }
+                  reject(err);
+                } else {
+                  resolve(data);
+                }
+              }
+            };
+            socket.on('response', onResponse);
+            const meta = {
+              event: event,
+              requestId: requestId
+            };
+            socket.emit('sendEvent', meta, ...data);
+          });
+        });
+      },
+
       addSocketEventListener: function(event, listener) {
         const info = {
           event: event,

--- a/lib/client-manager.js
+++ b/lib/client-manager.js
@@ -79,6 +79,7 @@ limitations under the License.
 
       socket.on('disconnect', () => this._handleSocketDisconnect(socket));
       socket.on('sendRequest', (...data) => this._handleSendRequest(socket, ...data));
+      socket.on('sendEvent', (...data) => this._handleSendEvent(socket, ...data));
       socket.on('addEventListener', (...data) => this._handleAddEventListener(socket, ...data));
       socket.on('removeEventListener', (...data) => this._handleRemoveEventListener(socket, ...data));
     }
@@ -92,6 +93,46 @@ limitations under the License.
         if (0 < eventInfo.count) {
           this._messageCenter.removeEventListener(event, eventInfo.listener);
         }
+      });
+    }
+
+    _handleSendEvent(socket, meta, ...data) {
+      const socketId = socket.id;
+      const socketInfo = this._socketInfos.get(socketId);
+      const scopes = socketInfo.scopes;
+      const event = meta.event;
+      const requestId = meta.requestId;
+      logger.silly(`Socket ${socket.id} sent '${event}'.`, {
+        socketId: socket.id,
+        event: event,
+        requestId: requestId,
+        data: data
+      });
+      const start = process.hrtime();
+      const responseMeta = {
+        event: event,
+        responseId: requestId,
+        duration: 0
+      };
+
+      this._messageCenter.sendEvent(event, {scopes: scopes}, ...data)
+      .then(() => {
+        const duration = calculateDuration(start);
+        responseMeta.duration = duration;
+        socket.emit('response', responseMeta);
+      })
+      .catch((err) => {
+        let error = err.error || err;
+        logger.warn('There was an error sending the eventt', error);
+        const duration = calculateDuration(start);
+        responseMeta.duration = duration;
+        if (error instanceof Error) {
+          error = {
+            name: err.name,
+            message: err.message
+          };
+        }
+        socket.emit('response', responseMeta, error, null);
       });
     }
 


### PR DESCRIPTION
Provide a sendEvent function for the BaseMessageCenterBehaviorImpl class, which sends
events to the server-side socket handler. Provide a handler function in client manager
which sends the requested event on the message center and returns the result status to
the remote socket.

resolves issue #32